### PR TITLE
Fix twig/twig conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "heimrichhannot/contao-utils-bundle": "^2.0"
   },
   "conflict": {
-    "twig/twig": "<1.38.0 || <2.7.0 ",
+    "twig/twig": "<1.38.0 || >2.0 <2.7.0",
     "ivory/google-map": "<3.0.4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "heimrichhannot/contao-utils-bundle": "^2.0"
   },
   "conflict": {
-    "twig/twig": "<1.38.0 || >2.0 <2.7.0",
+    "twig/twig": "<1.38.0 || >=2.0 <2.7.0",
     "ivory/google-map": "<3.0.4"
   },
   "autoload": {


### PR DESCRIPTION
I think your intention was to allow everything that is greater than version `1.38.0` or `2.7.0`. However, the current conflict will simply disallow anything below `2.7.0`, including all `1.x` versions that are actually greater than `1.38.0`. This currently disallows the installation in Contao 4.4 for example (since `twig/twig` `1.x` is used there).

This PR updates the conflict to allow `1.x` versions that are greating than `1.38.0`. See [semver.mwl.be](https://semver.mwl.be/#!?package=twig%2Ftwig&version=%3C1.38.0%20%7C%7C%20%3E%3D2.0%20%3C2.7.0&minimum-stability=stable) » anything that is highlighted in red will be disallowed.