### PR TITLE
Fix decoding of styles

### DIFF
--- a/src/Manager/MapManager.php
+++ b/src/Manager/MapManager.php
@@ -304,7 +304,7 @@ class MapManager
         }
 
         // styles
-        $map->setMapOption('styles', json_decode($mapConfig->styles, true));
+        $map->setMapOption('styles', json_decode(StringUtil::decodeEntities($mapConfig->styles), true));
     }
 
     public function setBehavior(Map $map, GoogleMapModel $mapConfig)


### PR DESCRIPTION
This PR fixes #9 

The styles need to be decoded because they are not saved decoded 👨‍💻!

Another solution would be to add `'decodeEntities' => true,`  to the `styles` field - here:
https://github.com/heimrichhannot/contao-google-maps-bundle/blob/a6e62d517ec9fac4c6821c82b5ee99c0f752e75b/src/Resources/contao/dca/tl_google_map.php#L260
But you would need to migrate all exisiting sytles - although they did not work for now 🐞 

I wondered if there might be a migration from dlh_googlemaps for the parameters (which support styles) but I did not find them in the migration. So the parameters are not migrated, aren't they? 🤔 