### PR TITLE
Add better list bundle support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   },
   "conflict": {
     "twig/twig": "<1.38.0 || >=2.0 <2.7.0",
-    "ivory/google-map": "<3.0.4"
+    "ivory/google-map": "<3.0.4",
+    "heimrichhannot/contao-google-maps-list-bundle": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Event/GoogleMapsPrepareExternalItemEvent.php
+++ b/src/Event/GoogleMapsPrepareExternalItemEvent.php
@@ -2,6 +2,7 @@
 
 namespace HeimrichHannot\GoogleMapsBundle\Event;
 
+use Contao\Model;
 use HeimrichHannot\GoogleMapsBundle\Model\OverlayModel;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -16,11 +17,16 @@ class GoogleMapsPrepareExternalItemEvent extends Event
      * @var OverlayModel
      */
     private $overlayModel;
+    /**
+     * @var Model
+     */
+    private $configModel;
 
-    public function __construct(array $itemData, OverlayModel $overlayModel)
+    public function __construct(array $itemData, OverlayModel $overlayModel, Model $configModel)
     {
         $this->itemData = $itemData;
         $this->overlayModel = $overlayModel;
+        $this->configModel = $configModel;
     }
 
     /**
@@ -45,6 +51,14 @@ class GoogleMapsPrepareExternalItemEvent extends Event
     public function setOverlayModel(OverlayModel $overlayModel): void
     {
         $this->overlayModel = $overlayModel;
+    }
+
+    /**
+     * @return Model
+     */
+    public function getConfigModel(): Model
+    {
+        return $this->configModel;
     }
 
 

--- a/src/Event/GoogleMapsPrepareExternalItemEvent.php
+++ b/src/Event/GoogleMapsPrepareExternalItemEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace HeimrichHannot\GoogleMapsBundle\Event;
+
+use HeimrichHannot\GoogleMapsBundle\Model\OverlayModel;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class GoogleMapsPrepareExternalItemEvent extends Event
+{
+
+    /**
+     * @var array
+     */
+    private $itemData;
+    /**
+     * @var OverlayModel
+     */
+    private $overlayModel;
+
+    public function __construct(array $itemData, OverlayModel $overlayModel)
+    {
+        $this->itemData = $itemData;
+        $this->overlayModel = $overlayModel;
+    }
+
+    /**
+     * @return array
+     */
+    public function getItemData(): array
+    {
+        return $this->itemData;
+    }
+
+    /**
+     * @return OverlayModel
+     */
+    public function getOverlayModel(): OverlayModel
+    {
+        return $this->overlayModel;
+    }
+
+    /**
+     * @param OverlayModel $overlayModel
+     */
+    public function setOverlayModel(OverlayModel $overlayModel): void
+    {
+        $this->overlayModel = $overlayModel;
+    }
+
+
+}

--- a/src/Event/GoogleMapsPrepareExternalItemEvent.php
+++ b/src/Event/GoogleMapsPrepareExternalItemEvent.php
@@ -46,17 +46,20 @@ class GoogleMapsPrepareExternalItemEvent extends Event
     }
 
     /**
-     * @param OverlayModel $overlayModel
+     * Set the overlay model for the current item.
+     * Set null to skip adding a marker for the current item.
+     *
+     * @param OverlayModel|null $overlayModel
      */
-    public function setOverlayModel(OverlayModel $overlayModel): void
+    public function setOverlayModel(OverlayModel $overlayModel = null): void
     {
         $this->overlayModel = $overlayModel;
     }
 
     /**
-     * @return Model
+     * @return Model|null
      */
-    public function getConfigModel(): Model
+    public function getConfigModel(): ?Model
     {
         return $this->configModel;
     }

--- a/src/EventListener/ReplaceDynamicScriptTagsListener.php
+++ b/src/EventListener/ReplaceDynamicScriptTagsListener.php
@@ -23,26 +23,29 @@ class ReplaceDynamicScriptTagsListener
         $this->mapManager = $mapManager;
     }
 
-    public function __invoke($buffer)
+    public function __invoke($buffer): string
     {
-        if ($mapApi = $this->mapManager->renderApi()) {
-            if (class_exists('HeimrichHannot\PrivacyCenterBundle\HeimrichHannotPrivacyCenterBundle')) {
-                // fix the code for the case more than 1 map is on the page and not the first one is clicked
-                $mapApi = preg_replace(
-                    '@(ivory_google_map_init_requirement\()(ivory_google_map_map_[^,]+)@i',
-                    'typeof $2 !== \'undefined\' && $1$2', $mapApi);
+        $mapApi = $this->mapManager->renderApi();
+        if (empty($mapApi)) {
+            return $buffer;
+        }
 
-                // protect the code
-                $GLOBALS['TL_HEAD']['huhGoogleMaps'] = PrivacyCenterManager::getInstance()->addProtectedCode(
-                    $mapApi,
-                    ['google_maps'],
-                    [
-                        'addPoster' => false,
-                    ]
-                );
-            } else {
-                $GLOBALS['TL_BODY']['huhGoogleMaps'] = $mapApi;
-            }
+        // fix the code for the case more than 1 map is on the page and not the first one is clicked
+        $mapApi = preg_replace(
+            '@(ivory_google_map_init_requirement\()(ivory_google_map_map_[^,]+)@i',
+            'typeof $2 !== \'undefined\' && $1$2', $mapApi);
+
+        if (class_exists('HeimrichHannot\PrivacyCenterBundle\HeimrichHannotPrivacyCenterBundle')) {
+            // protect the code
+            $GLOBALS['TL_BODY']['huhGoogleMaps'] = PrivacyCenterManager::getInstance()->addProtectedCode(
+                $mapApi,
+                ['google_maps'],
+                [
+                    'addPoster' => false,
+                ]
+            );
+        } else {
+            $GLOBALS['TL_BODY']['huhGoogleMaps'] = $mapApi;
         }
 
         return $buffer;

--- a/src/EventSubscriber/ListBundleSubscriber.php
+++ b/src/EventSubscriber/ListBundleSubscriber.php
@@ -115,15 +115,16 @@ class ListBundleSubscriber implements EventSubscriberInterface
 
     public function transformItemsToOverlays(array $items, ListConfigModel $configModel)
     {
-        $eventDispatcher = $this->eventDispatcher;
-        $models = array_map(function ($item) use ($eventDispatcher, $configModel) {
+        $models = [];
+        foreach ($items as $item) {
             $overlay = new OverlayModel();
             $overlay->setRow($item);
             /** @var GoogleMapsPrepareExternalItemEvent $event */
-            $event = $eventDispatcher->dispatch(new GoogleMapsPrepareExternalItemEvent($item, $overlay, $configModel));
-            return $event->getOverlayModel();
-        }, $items);
-
+            $event = $this->eventDispatcher->dispatch(new GoogleMapsPrepareExternalItemEvent($item, $overlay, $configModel));
+            if ($overlay = $event->getOverlayModel()) {
+                $models[] = $overlay;
+            }
+        }
         return new Collection($models, 'tl_google_map_overlay');
     }
 }

--- a/src/EventSubscriber/ListBundleSubscriber.php
+++ b/src/EventSubscriber/ListBundleSubscriber.php
@@ -9,6 +9,7 @@ use HeimrichHannot\GoogleMapsBundle\Manager\OverlayManager;
 use HeimrichHannot\GoogleMapsBundle\Model\OverlayModel;
 use HeimrichHannot\ListBundle\Event\ListBeforeParseItemsEvent;
 use HeimrichHannot\ListBundle\Event\ListBeforeRenderEvent;
+use HeimrichHannot\ListBundle\Model\ListConfigModel;
 use HeimrichHannot\UtilsBundle\Model\ModelUtil;
 use Model\Collection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -67,7 +68,7 @@ class ListBundleSubscriber implements EventSubscriberInterface
         }
 
         $mapId = $event->getListConfig()->itemMap;
-        $overlays = $this->transformItemsToOverlays($event->getItems());
+        $overlays = $this->transformItemsToOverlays($event->getItems(), $event->getListConfig());
         $templateData = $this->mapManager->prepareMap($mapId, $map->row(), $overlays);
 
         if (null === $templateData) {
@@ -112,14 +113,14 @@ class ListBundleSubscriber implements EventSubscriberInterface
         $event->setTemplateData($templateData);
     }
 
-    public function transformItemsToOverlays(array $items)
+    public function transformItemsToOverlays(array $items, ListConfigModel $configModel)
     {
         $eventDispatcher = $this->eventDispatcher;
-        $models = array_map(function ($item) use ($eventDispatcher) {
+        $models = array_map(function ($item) use ($eventDispatcher, $configModel) {
             $overlay = new OverlayModel();
             $overlay->setRow($item);
             /** @var GoogleMapsPrepareExternalItemEvent $event */
-            $event = $eventDispatcher->dispatch(new GoogleMapsPrepareExternalItemEvent($item, $overlay));
+            $event = $eventDispatcher->dispatch(new GoogleMapsPrepareExternalItemEvent($item, $overlay, $configModel));
             return $event->getOverlayModel();
         }, $items);
 

--- a/src/EventSubscriber/ListBundleSubscriber.php
+++ b/src/EventSubscriber/ListBundleSubscriber.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace HeimrichHannot\GoogleMapsBundle\EventSubscriber;
+
+use Contao\Environment;
+use HeimrichHannot\GoogleMapsBundle\Event\GoogleMapsPrepareExternalItemEvent;
+use HeimrichHannot\GoogleMapsBundle\Manager\MapManager;
+use HeimrichHannot\GoogleMapsBundle\Manager\OverlayManager;
+use HeimrichHannot\GoogleMapsBundle\Model\OverlayModel;
+use HeimrichHannot\ListBundle\Event\ListBeforeParseItemsEvent;
+use HeimrichHannot\ListBundle\Event\ListBeforeRenderEvent;
+use HeimrichHannot\UtilsBundle\Model\ModelUtil;
+use Model\Collection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class ListBundleSubscriber implements EventSubscriberInterface
+{
+    private $mapManager;
+    /**
+     * @var ModelUtil
+     */
+    private $modelUtil;
+    /**
+     * @var OverlayManager
+     */
+    private $overlayManager;
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /** @var array  */
+    private $maps = [];
+
+    public function __construct(MapManager $mapManager, ModelUtil $modelUtil, OverlayManager $overlayManager, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->mapManager = $mapManager;
+        $this->modelUtil = $modelUtil;
+        $this->overlayManager = $overlayManager;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        $subscriptions = [];
+
+        if (class_exists('HeimrichHannot\ListBundle\Event\ListBeforeParseItemsEvent')) {
+            $subscriptions[ListBeforeParseItemsEvent::NAME] = 'onListBeforeParseItemsEvent';
+        }
+
+        if (class_exists('HeimrichHannot\ListBundle\Event\ListBeforeRenderEvent')) {
+            $subscriptions[ListBeforeRenderEvent::NAME] = 'onListBeforeRenderEvent';
+        }
+
+        return $subscriptions;
+    }
+
+    public function onListBeforeParseItemsEvent(ListBeforeParseItemsEvent $event): void
+    {
+        if (!$event->getListConfig()->renderItemsAsMap) {
+            return;
+        }
+        if (null === ($map = $this->modelUtil->findModelInstanceByPk('tl_google_map',
+                $event->getListConfig()->itemMap))) {
+            return;
+        }
+
+        $mapId = $event->getListConfig()->itemMap;
+        $overlays = $this->transformItemsToOverlays($event->getItems());
+        $templateData = $this->mapManager->prepareMap($mapId, $map->row(), $overlays);
+
+        if (null === $templateData) {
+            return;
+        }
+
+        $this->maps[$mapId] = $templateData['mapModel'];
+
+        $markerVariableMapping = $this->overlayManager->getMarkerVariableMapping();
+
+        $items = [];
+
+        foreach ($event->getItems() as $item) {
+            $item['markerVariable'] = $markerVariableMapping[$item['id']];
+            $item['markerHref']     = Environment::get('uri') . '#' . $markerVariableMapping[$item['id']];
+
+            $items[] = $item;
+        }
+
+        $event->setItems($items);
+    }
+
+    public function onListBeforeRenderEvent(ListBeforeRenderEvent $event): void
+    {
+        if (!$event->getListConfig()->renderItemsAsMap) {
+            return;
+        }
+
+        $listConfig = $event->getListConfig();
+        $mapId = $listConfig->itemMap;
+
+        if (!isset($this->maps[$mapId])) {
+            return;
+        }
+
+        $templateData = $event->getTemplateData();
+
+        $templateData['renderedMap'] = $this->mapManager->renderMapObject($this->maps[$mapId], $mapId);
+        // $this->mapManager->render($listConfig->itemMap, $map->row(), $overlays);
+        $templateData['addMapControlList'] = (bool)$listConfig->addMapControlList;
+
+        $event->setTemplateData($templateData);
+    }
+
+    public function transformItemsToOverlays(array $items)
+    {
+        $eventDispatcher = $this->eventDispatcher;
+        $models = array_map(function ($item) use ($eventDispatcher) {
+            $overlay = new OverlayModel();
+            $overlay->setRow($item);
+            /** @var GoogleMapsPrepareExternalItemEvent $event */
+            $event = $eventDispatcher->dispatch(new GoogleMapsPrepareExternalItemEvent($item, $overlay));
+            return $event->getOverlayModel();
+        }, $items);
+
+        return new Collection($models, 'tl_google_map_overlay');
+    }
+}

--- a/src/Manager/MapManager.php
+++ b/src/Manager/MapManager.php
@@ -155,9 +155,9 @@ class MapManager
         return $templateData;
     }
 
-    public function render(int $mapId, array $config = [])
+    public function render(int $mapId, array $config = [], Collection $overlays = null)
     {
-        $templateData = $this->prepareMap($mapId, $config);
+        $templateData = $this->prepareMap($mapId, $config, $overlays);
 
         if (null === $templateData) {
             return null;
@@ -166,24 +166,7 @@ class MapManager
         /** @var Map $map */
         $map = $templateData['mapModel'];
 
-        $mapHelper = MapHelperBuilder::create()->build();
-
-        $listener = new MapRendererListener($templateData['mapConfigModel'], $this, $mapHelper);
-        $mapHelper->getEventDispatcher()->addListener('map.stylesheet', [$listener, 'renderStylesheet']);
-
-        $templateData['mapHtml'] = $mapHelper->renderHtml($map);
-        $templateData['mapCss'] = $mapHelper->renderStylesheet($map);
-        $templateData['mapJs'] = $mapHelper->renderJavascript($map);
-        $this->mapCollection->addMap($map, $mapId);
-
-        $template = $templateData['mapConfig']['template'] ?: 'gmap_map_default';
-        $template = System::getContainer()->get('huh.utils.template')->getTemplate($template);
-
-        /** @var BeforeRenderMapEvent $event */
-        /** @noinspection PhpParamsInspection */
-        $event = $this->eventDispatcher->dispatch(new BeforeRenderMapEvent($template, $templateData, $map), BeforeRenderMapEvent::NAME);
-
-        return $this->twig->render($event->getTemplate(), $event->getTemplateData());
+        return $this->renderMapObject($map, $mapId);
     }
 
     public function renderMapObject(Map $map, ?int $mapId = null)

--- a/src/Manager/OverlayManager.php
+++ b/src/Manager/OverlayManager.php
@@ -255,7 +255,7 @@ class OverlayManager
 
                 case Overlay::CLICK_EVENT_INFO_WINDOW:
                     $infoWindow = $this->prepareInfoWindow($overlayConfig);
-                    $infoWindow->setPixelOffset(new Size($overlayConfig->infoWindowAnchorX, $overlayConfig->infoWindowAnchorY));
+                    $infoWindow->setPixelOffset(new Size(($overlayConfig->infoWindowAnchorX ?? 0), $overlayConfig->infoWindowAnchorY ?? 0));
                     $infoWindow->setOpenEvent(MouseEvent::CLICK);
                     // caution: this autoOpen is different from the one in dlh google maps
                     $infoWindow->setAutoOpen(true);

--- a/src/Model/OverlayModel.php
+++ b/src/Model/OverlayModel.php
@@ -8,7 +8,51 @@
 
 namespace HeimrichHannot\GoogleMapsBundle\Model;
 
-class OverlayModel extends \Model
+use Contao\Model;
+
+/**
+ * @property string $id
+ * @property string $pid
+ * @property string $tstamp
+ * @property string $dateAdded
+ * @property string $title
+ * @property string $type
+ * @property string $titleMode
+ * @property string $titleText
+ * @property string $positioningMode
+ * @property string $positioningLat
+ * @property string $positioningLng
+ * @property string $positioningAddress
+ * @property string $infoWindowWidth
+ * @property string $infoWindowHeight
+ * @property string $infoWindowText
+ * @property string $addRouting
+ * @property string $routingAddress
+ * @property string $routingTemplate
+ * @property string $animation
+ * @property string $markerType
+ * @property string $iconSrc
+ * @property string $iconWidth
+ * @property string $iconHeight
+ * @property string $iconAnchorX
+ * @property string $iconAnchorY
+ * @property string $clickEvent
+ * @property string $url
+ * @property string $target
+ * @property string $infoWindowAnchorX
+ * @property string $infoWindowAnchorY
+ * @property string $kmlUrl
+ * @property string $kmlClickable
+ * @property string $kmlPreserveViewport
+ * @property string $kmlScreenOverlays
+ * @property string $kmlSuppressInfowindows
+ * @property string $zIndex
+ * @property string $published
+ * @property string $start
+ * @property string $stop
+ *
+ */
+class OverlayModel extends Model
 {
     protected static $strTable = 'tl_google_map_overlay';
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,5 +1,10 @@
 services:
 
+  HeimrichHannot\GoogleMapsBundle\EventSubscriber\:
+    resource: '../../EventSubscriber/*'
+    autowire: true
+    autoconfigure: true
+
   HeimrichHannot\GoogleMapBundle\ConfigElementType\GoogleMapConfigElementType:
     autowire: true
     tags: ['huh.list.config_element_type', 'huh.reader.config_element_type']

--- a/src/Resources/contao/languages/de/tl_list_config.php
+++ b/src/Resources/contao/languages/de/tl_list_config.php
@@ -1,0 +1,17 @@
+<?php
+
+$lang = &$GLOBALS['TL_LANG']['tl_list_config'];
+
+/**
+ * Fields
+ */
+$lang['renderItemsAsMap'][0]  = 'Instanzen als Karte ausgeben';
+$lang['renderItemsAsMap'][1]  = 'Wählen Sie diese Option, um die gefundenen Instanzen der Liste in Form einer Karte auszugeben.';
+$lang['addMapControlList'][0] = 'Instanzen neben der Karte auch als Liste ausgeben';
+$lang['addMapControlList'][1] = 'Wählen Sie diese Option, um neben der Karte auch eine (filterbare) Liste der Instanzen zur Steuerung der Karte auszugeben.';
+
+/**
+ * Legends
+ */
+
+$lang['google_maps_legend'] = "Google Maps";

--- a/src/Resources/contao/languages/en/tl_list_config.php
+++ b/src/Resources/contao/languages/en/tl_list_config.php
@@ -1,0 +1,17 @@
+<?php
+
+$lang = &$GLOBALS['TL_LANG']['tl_list_config'];
+
+/**
+ * Fields
+ */
+$lang['renderItemsAsMap'][0]  = 'Render items as map';
+$lang['renderItemsAsMap'][1]  = 'Select this option to display instances of this list as map.';
+$lang['addMapControlList'][0] = 'Show instances also as list';
+$lang['addMapControlList'][1] = 'Choose this option to show a (filterable) list of the list items next to the map to control the map.';
+
+/**
+ * Legends
+ */
+
+$lang['google_maps_legend'] = "Google Maps";

--- a/src/Resources/views/list_google_maps_default.html.twig
+++ b/src/Resources/views/list_google_maps_default.html.twig
@@ -1,0 +1,32 @@
+<div {% block attributes %}class="wrapper{{ wrapperClass|default() ? ' ' ~ wrapperClass : '' }}" id="{{ wrapperId }}"{% endblock %}>
+    {% if showInitialResults or submitted %}
+        {% if showItemCount %}
+            <p class="count">{{ itemsFoundText|raw }}</p>
+        {% endif %}
+
+        {% if items is not empty %}
+            {% if addMapControlList|default %}
+                <div class="wrapper">
+                    <div class="map">
+                        {{ renderedMap|default|raw }}
+                    </div>
+
+                    <div class="control-list">
+                        <div class="items{{ itemsClass|default() ? ' ' ~ itemsClass : '' }}"{{ dataAttributes|default()|raw }}>
+                            {% for item in items %}
+                                {{ item|raw }}
+                            {% endfor %}
+                        </div>
+                        {{ pagination|default()|raw }}
+                    </div>
+                </div>
+            {% else %}
+                <div class="map">
+                    {{ renderedMap|default|raw }}
+                </div>
+            {% endif %}
+        {% elseif showNoItemsText %}
+            <p class="no-items">{{ noItemsText|raw }}</p>
+        {% endif %}
+    {% endif %}
+</div>

--- a/src/Resources/views/list_item_google_maps_default.html.twig
+++ b/src/Resources/views/list_item_google_maps_default.html.twig
@@ -1,0 +1,15 @@
+<div class="{{ cssClass }}">
+    <a id="list-item-{{ markerVariable }}" href="#">
+        {{ title|raw }}
+    </a>
+
+    <script type="text/javascript">
+        function trigger_{{ markerVariable }}(event) {
+            event.preventDefault();
+
+            new google.maps.event.trigger({{ markerVariable }}, 'click');
+        }
+
+        document.getElementById('list-item-{{ markerVariable }}').addEventListener('click', trigger_{{ markerVariable }});
+    </script>
+</div>


### PR DESCRIPTION
This PR enhances the list bundle support. The main change is the inclusion of contao-google-maps-list-bundle into this bundle with some enhancements and lose coupling.

Following changes were made:
- Added an event subscriber for list events to add google maps logic to lists (no need of a custom list class anymore)
- Update LoadDataContainer listener to add fields if list bundle is installed
- Added GoogleMapsPrepareExternalItemEvent to customize Marker data from external sources (currently only implemented for Lists, but can be further used in the future due generic implementation)
- FIxes uneven script inclusion for consent bars
- Fixed marker infowindow option not working with empty offset fields