### PR TITLE
Enhance list config element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2021-10-27
+- Changed: use GoogleMapsPrepareExternalItemEvent in list and reader config element
+- Deprecated: ListGoogleMapBeforeRenderEvent (use GoogleMapsPrepareExternalItemEvent instead)
+- Deprecated: ReaderGoogleMapBeforeRenderEvent (use GoogleMapsPrepareExternalItemEvent instead)
+
 ## [2.1.1] - 2021-10-27
 - Fixed: return values in GoogleMapsPrepareExternalItemEvent
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade notices
 
+## to 3.x
+- replaced ListGoogleMapBeforeRenderEvent with GoogleMapsPrepareExternalItemEvent
+- replaced ReaderGoogleMapBeforeRenderEvent with GoogleMapsPrepareExternalItemEvent
+
 ## to 2.1
 - Remove heimrichhannot/contao-google-maps-list-bundle dependency
 - Update your list configs to don't use `HeimrichHannot\GoogleMapsListBundle\DefaultList` and `HeimrichHannot\GoogleMapsListBundle\DefaultItem` anymore

--- a/src/Event/ListGoogleMapBeforeRenderEvent.php
+++ b/src/Event/ListGoogleMapBeforeRenderEvent.php
@@ -13,6 +13,9 @@ use HeimrichHannot\ListBundle\Item\ItemInterface;
 use HeimrichHannot\ListBundle\Model\ListConfigElementModel;
 use Ivory\GoogleMap\Map;
 
+/**
+ * @deprecated Use GoogleMapsPrepareExternalItemEvent instead
+ */
 class ListGoogleMapBeforeRenderEvent extends GoogleMapBeforeRenderEvent
 {
     const NAME = 'huh.google_maps.event.list_before_render';

--- a/src/Event/ReaderGoogleMapBeforeRenderEvent.php
+++ b/src/Event/ReaderGoogleMapBeforeRenderEvent.php
@@ -13,6 +13,9 @@ use HeimrichHannot\ReaderBundle\Item\ItemInterface;
 use HeimrichHannot\ReaderBundle\Model\ReaderConfigElementModel;
 use Ivory\GoogleMap\Map;
 
+/**
+ * @deprecated Use GoogleMapsPrepareExternalItemEvent instead
+ */
 class ReaderGoogleMapBeforeRenderEvent extends GoogleMapBeforeRenderEvent
 {
     const NAME = 'huh.google_maps.event.reader_before_render';

--- a/src/Model/GoogleMapModel.php
+++ b/src/Model/GoogleMapModel.php
@@ -10,6 +10,11 @@ namespace HeimrichHannot\GoogleMapsBundle\Model;
 
 use Contao\Model;
 
+/**
+ * @property string $positioningMode
+ * @property string $boundMode
+ * @property string $centerMode
+ */
 class GoogleMapModel extends Model
 {
     protected static $strTable = 'tl_google_map';


### PR DESCRIPTION
This PR enhances the config element type supporting GoogleMapsPrepareExternalItemEvent and supporting external center mode. It also deprecates the specific list and reader events.

Due the list and reader events, it isn't currently possible to change the config element type to ConfigElementTypeInterface. That would be a BC break.