### PR TITLE
Fix migration of iconAnchor

### DIFF
--- a/src/Command/MigrateDlhCommand.php
+++ b/src/Command/MigrateDlhCommand.php
@@ -475,8 +475,8 @@ class MigrateDlhCommand extends Command
 
                     $iconAnchor = StringUtil::deserialize($legacyOverlay->iconAnchor, true);
 
-                    $overlay->iconAnchorX = ['value' => $iconAnchor[0], 'unit' => 'px'];
-                    $overlay->iconAnchorY = ['value' => $iconAnchor[1], 'unit' => 'px'];
+                    $overlay->iconAnchorX = (int) $iconAnchor[0];
+                    $overlay->iconAnchorY = (int) $iconAnchor[1];
 
                     break;
             }


### PR DESCRIPTION
The database fields of iconAnchor are of the type integer and not unit. This has to be fixed in the migration. 
Otherwise the following error occurred:  ```An exception occurred while executing a query: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: 'a:2:{s:5:"value";s:1:"0";s:4:"unit";s:2:"px";}' for column `lamp`.`tl_google_map_overlay`.`iconAnchorX` at row 1``` 

Thanks @rabauss    