### PR TITLE
Switch to ivory/google-map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "doctrine/dbal": "^2.11 || ^3.0",
     "heimrichhannot/contao-twig-support-bundle": "^0.2.16 || ^1.0",
     "heimrichhannot/contao-utils-bundle": "^2.213",
-    "ivory/google-map": "^3.0",
+    "ivory/google-map": "^3.0 || ^5.0 || ^6.0",
     "mvo/contao-group-widget": "^1.4",
     "symfony/config": "^4.4 || ^5.0",
     "symfony/console": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "heimrichhannot/contao-google-maps-bundle",
   "type": "contao-bundle",
-  "description": "This bundle offers functionality concerning the Google Maps v3 API. It acts as a contao wrapper for ivory/google-map-bundle.",
+  "description": "This bundle adds google maps integration to Contao.",
   "license": "LGPL-3.0-or-later",
   "require": {
     "php": "^7.4 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "heimrichhannot/contao-google-maps-bundle",
   "type": "contao-bundle",
-  "description": "This bundle offers functionality concerning the Google Maps v3 API. It acts as a contao wrapper for egeloen/ivory-google-map and egeloen/IvoryGoogleMapBundle.",
+  "description": "This bundle offers functionality concerning the Google Maps v3 API. It acts as a contao wrapper for ivory/google-map-bundle.",
   "license": "LGPL-3.0-or-later",
   "require": {
     "php": "^7.4 || ^8.0",
@@ -9,7 +9,7 @@
     "doctrine/dbal": "^2.11 || ^3.0",
     "heimrichhannot/contao-twig-support-bundle": "^0.2.16 || ^1.0",
     "heimrichhannot/contao-utils-bundle": "^2.213",
-    "ivory/google-map-bundle": "^3.0",
+    "ivory/google-map": "^3.0",
     "mvo/contao-group-widget": "^1.4",
     "symfony/config": "^4.4 || ^5.0",
     "symfony/console": "^4.4 || ^5.0",
@@ -32,28 +32,6 @@
   "autoload": {
     "psr-4": {
       "HeimrichHannot\\GoogleMapsBundle\\": "src/"
-    },
-    "classmap": [
-      "src/"
-    ],
-    "exclude-from-classmap": [
-      "src/Resources/contao/config/",
-      "src/Resources/contao/dca/",
-      "src/Resources/contao/languages/",
-      "src/Resources/contao/templates/"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "HeimrichHannot\\GoogleMapsBundle\\Test\\": "tests/"
-    }
-  },
-  "config": {
-    "preferred-install": "dist",
-    "allow-plugins": {
-      "composer/package-versions-deprecated": true,
-      "contao-components/installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "extra": {

--- a/src/ConfigElementType/GoogleMapConfigElementType.php
+++ b/src/ConfigElementType/GoogleMapConfigElementType.php
@@ -6,7 +6,7 @@
  * @license LGPL-3.0-or-later
  */
 
-namespace HeimrichHannot\GoogleMapBundle\ConfigElementType;
+namespace HeimrichHannot\GoogleMapsBundle\ConfigElementType;
 
 use Contao\Model;
 use Contao\Model\Collection;

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -13,8 +13,9 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use HeimrichHannot\GoogleMapsBundle\HeimrichHannotGoogleMapsBundle;
+use HeimrichHannot\ListBundle\HeimrichHannotContaoListBundle;
+use HeimrichHannot\ReaderBundle\HeimrichHannotContaoReaderBundle;
 use Hofff\Contao\Consent\Bridge\HofffContaoConsentBridgeBundle;
-use Ivory\GoogleMapBundle\IvoryGoogleMapBundle;
 
 class Plugin implements BundlePluginInterface
 {
@@ -23,23 +24,13 @@ class Plugin implements BundlePluginInterface
      */
     public function getBundles(ParserInterface $parser)
     {
-        $loadAfterBundles = [ContaoCoreBundle::class, IvoryGoogleMapBundle::class];
-
-        if (class_exists('HeimrichHannot\ReaderBundle\HeimrichHannotContaoReaderBundle')) {
-            $loadAfterBundles[] = 'HeimrichHannot\ReaderBundle\HeimrichHannotContaoReaderBundle';
-        }
-
-        if (class_exists('HeimrichHannot\ListBundle\HeimrichHannotContaoListBundle')) {
-            $loadAfterBundles[] = 'HeimrichHannot\ListBundle\HeimrichHannotContaoListBundle';
-        }
-        
-        if (class_exists(HofffContaoConsentBridgeBundle::class)) {
-            $loadAfterBundles[] = HofffContaoConsentBridgeBundle::class;
-        }
-
         return [
-            BundleConfig::create(IvoryGoogleMapBundle::class)->setLoadAfter([ContaoCoreBundle::class]),
-            BundleConfig::create(HeimrichHannotGoogleMapsBundle::class)->setLoadAfter($loadAfterBundles),
+            BundleConfig::create(HeimrichHannotGoogleMapsBundle::class)->setLoadAfter([
+                ContaoCoreBundle::class,
+                HeimrichHannotContaoReaderBundle::class,
+                HeimrichHannotContaoListBundle::class,
+                HofffContaoConsentBridgeBundle::class,
+            ]),
         ];
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,7 +19,7 @@ services:
     alias: HeimrichHannot\GoogleMapsBundle\Manager\OverlayManager
     public: true
 
-  HeimrichHannot\GoogleMapBundle\ConfigElementType\GoogleMapConfigElementType:
+  HeimrichHannot\GoogleMapsBundle\ConfigElementType\GoogleMapConfigElementType:
     tags: ['huh.list.config_element_type', 'huh.reader.config_element_type']
 
   HeimrichHannot\GoogleMapsBundle\Collection\MapCollection: ~


### PR DESCRIPTION
This PR replace the [ivory/google-map-bundle](https://github.com/bresam/ivory-google-map-bundle) dependency with ivory/google-map. It also allows newer version of the library.