### PR TITLE
Unlock symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     "heimrichhannot/contao-utils-bundle": "^3.6",
     "ivory/google-map": "^6.0",
     "mvo/contao-group-widget": "^1.5",
-    "symfony/config": "^6.4",
-    "symfony/console": "^6.4",
-    "symfony/dependency-injection": "^6.4",
-    "symfony/event-dispatcher": "^6.4",
-    "symfony/http-foundation": "^6.4",
-    "symfony/http-kernel": "^6.4",
+    "symfony/config": "^6.4 || ^7.0",
+    "symfony/console": "^6.4 || ^7.0",
+    "symfony/dependency-injection": "^6.4 || ^7.0",
+    "symfony/event-dispatcher": "^6.4 || ^7.0",
+    "symfony/http-foundation": "^6.4 || ^7.0",
+    "symfony/http-kernel": "^6.4 || ^7.0",
     "twig/twig": "^3.15"
   },
   "require-dev": {

--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_content.php
+++ b/contao/dca/tl_content.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_google_map.php
+++ b/contao/dca/tl_google_map.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_google_map_overlay.php
+++ b/contao/dca/tl_google_map_overlay.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_module.php
+++ b/contao/dca/tl_module.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_page.php
+++ b/contao/dca/tl_page.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_settings.php
+++ b/contao/dca/tl_settings.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $dca = &$GLOBALS['TL_DCA']['tl_settings'];
 
 /*

--- a/contao/dca/tl_user.php
+++ b/contao/dca/tl_user.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/dca/tl_user_group.php
+++ b/contao/dca/tl_user_group.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/languages/de/default.php
+++ b/contao/languages/de/default.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/languages/de/modules.php
+++ b/contao/languages/de/modules.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_content.php
+++ b/contao/languages/de/tl_content.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_content'];
 
 /*

--- a/contao/languages/de/tl_google_map.php
+++ b/contao/languages/de/tl_google_map.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_google_map_overlay.php
+++ b/contao/languages/de/tl_google_map_overlay.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/contao/languages/de/tl_module.php
+++ b/contao/languages/de/tl_module.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_module'];
 
 /*

--- a/contao/languages/de/tl_page.php
+++ b/contao/languages/de/tl_page.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_page'];
 
 /*

--- a/contao/languages/de/tl_settings.php
+++ b/contao/languages/de/tl_settings.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_settings'];
 
 /*

--- a/contao/languages/de/tl_user.php
+++ b/contao/languages/de/tl_user.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_user'];
 
 /*

--- a/contao/languages/de/tl_user_group.php
+++ b/contao/languages/de/tl_user_group.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_user_group'];
 
 /*

--- a/contao/languages/en/modules.php
+++ b/contao/languages/en/modules.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $GLOBALS['TL_LANG']['MOD']['google_maps'] = ['Google Maps', ''];

--- a/contao/languages/en/tl_google_map.php
+++ b/contao/languages/en/tl_google_map.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_google_map'];
 
 /*

--- a/contao/languages/en/tl_google_map_overlay.php
+++ b/contao/languages/en/tl_google_map_overlay.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_google_map_overlay'];
 
 /*

--- a/contao/languages/en/tl_list_config.php
+++ b/contao/languages/en/tl_list_config.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_list_config'];
 
 /*

--- a/contao/languages/en/tl_page.php
+++ b/contao/languages/en/tl_page.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_page'];
 
 /*

--- a/contao/languages/en/tl_settings.php
+++ b/contao/languages/en/tl_settings.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_settings'];
 
 /*

--- a/contao/languages/en/tl_user.php
+++ b/contao/languages/en/tl_user.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_user'];
 
 /*

--- a/contao/languages/en/tl_user_group.php
+++ b/contao/languages/en/tl_user_group.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
-
 $lang = &$GLOBALS['TL_LANG']['tl_user_group'];
 
 /*

--- a/src/Collection/MapCollection.php
+++ b/src/Collection/MapCollection.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Command/MigrateDlhCommand.php
+++ b/src/Command/MigrateDlhCommand.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
@@ -79,7 +79,8 @@ class MigrateDlhCommand extends Command
             $this->io->note('Dry run enabled.');
             $this->io->newLine();
         }
-        $this->io->getFormatter()->setStyle('userwarning', new OutputFormatterStyle('red', null));
+        $this->io->getFormatter()
+            ->setStyle('userwarning', new OutputFormatterStyle('red', null));
 
         $this->framework->initialize();
 

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Controller/ContentElement/GoogleMapsElementController.php
+++ b/src/Controller/ContentElement/GoogleMapsElementController.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Controller/FrontendModule/GoogleMapsFrontendModuleController.php
+++ b/src/Controller/FrontendModule/GoogleMapsFrontendModuleController.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/DependencyInjection/GoogleMapsExtension.php
+++ b/src/DependencyInjection/GoogleMapsExtension.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Event/BeforeRenderApiEvent.php
+++ b/src/Event/BeforeRenderApiEvent.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Event/BeforeRenderMapEvent.php
+++ b/src/Event/BeforeRenderMapEvent.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Event/DlhMigrationModifyMapEvent.php
+++ b/src/Event/DlhMigrationModifyMapEvent.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Event/DlhMigrationModifyOverlayEvent.php
+++ b/src/Event/DlhMigrationModifyOverlayEvent.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Event/GoogleMapBeforeRenderEvent.php
+++ b/src/Event/GoogleMapBeforeRenderEvent.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Event/GoogleMapsPrepareExternalItemEvent.php
+++ b/src/Event/GoogleMapsPrepareExternalItemEvent.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/ApiRenderListener.php
+++ b/src/EventListener/ApiRenderListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/ConsentBridgeListener.php
+++ b/src/EventListener/ConsentBridgeListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/ContentListener.php
+++ b/src/EventListener/DataContainer/ContentListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/GoogleMapListener.php
+++ b/src/EventListener/DataContainer/GoogleMapListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
@@ -182,7 +182,8 @@ class GoogleMapListener
             return;
         }
 
-        $objSessionBag = $this->requestStack->getSession()->getBag('contao_backend');
+        $objSessionBag = $this->requestStack->getSession()
+            ->getBag('contao_backend');
         $newRecords = $objSessionBag->get('new_records');
 
         if (\is_array($newRecords['tl_google_map']) && \in_array($insertId, $newRecords['tl_google_map'], true)) {
@@ -218,7 +219,8 @@ class GoogleMapListener
                     ->from('tl_user')
                 ;
                 $qb->where($qb->expr()->eq('id', $user->id));
-                $userPermissions = $qb->executeQuery()->fetchAssociative();
+                $userPermissions = $qb->executeQuery()
+                    ->fetchAssociative();
 
                 $mapPermissions = StringUtil::deserialize($userPermissions['contao_google_maps_bundlep']);
 

--- a/src/EventListener/DataContainer/MapWizardListener.php
+++ b/src/EventListener/DataContainer/MapWizardListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/ModuleListener.php
+++ b/src/EventListener/DataContainer/ModuleListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/DataContainer/OverlayListener.php
+++ b/src/EventListener/DataContainer/OverlayListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
@@ -34,7 +34,8 @@ class InsertTagsListener implements InsertTagResolverNestedResolvedInterface
     {
         $this->framework->initialize();
 
-        $mapId = (int) $insertTag->getParameters()->get(0);
+        $mapId = (int) $insertTag->getParameters()
+            ->get(0);
 
         return match ($insertTag->getName()) {
             'google_map' => new InsertTagResult(

--- a/src/EventListener/MapRendererListener.php
+++ b/src/EventListener/MapRendererListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
@@ -31,7 +31,8 @@ class MapRendererListener
 
     public function renderStylesheet(MapEvent $event, string $eventName, EventDispatcherInterface $dispatcher): void
     {
-        $this->mapHelper->getEventDispatcher()->removeListener('map.stylesheet', [$this, 'renderStylesheet']);
+        $this->mapHelper->getEventDispatcher()
+            ->removeListener('map.stylesheet', [$this, 'renderStylesheet']);
 
         $responsiveSettings = StringUtil::deserialize($this->model->responsive, true);
 
@@ -59,7 +60,9 @@ class MapRendererListener
             '.$event->getMap()->getVariable().'.setCenter(center);
         }');
 
-        $event->getMap()->getEventManager()->addDomEvent($resizeEvent);
+        $event->getMap()
+            ->getEventManager()
+            ->addDomEvent($resizeEvent);
     }
 
     public function getManager(): MapManager

--- a/src/EventListener/OveleonContaoCookiebarListener.php
+++ b/src/EventListener/OveleonContaoCookiebarListener.php
@@ -66,7 +66,9 @@ class OveleonContaoCookiebarListener
             return;
         }
 
-        $listeners = $event->getApiHelper()->getEventDispatcher()->getListeners(ApiEvents::JAVASCRIPT);
+        $listeners = $event->getApiHelper()
+            ->getEventDispatcher()
+            ->getListeners(ApiEvents::JAVASCRIPT);
         $apiSubscriber = null;
 
         foreach ($listeners as $listener) {
@@ -84,7 +86,8 @@ class OveleonContaoCookiebarListener
         }
 
         $apiRenderer = $apiSubscriber->getApiRenderer();
-        $source = $apiRenderer->getLoaderRenderer()->renderSource('ivory_google_map_init', $event->getApiEvent()->getLibraries());
+        $source = $apiRenderer->getLoaderRenderer()
+            ->renderSource('ivory_google_map_init', $event->getApiEvent()->getLibraries());
 
         $this->addScriptToGlobals($this->maskExternalResource($source, $config['id'], 'gmap_library'));
 
@@ -150,7 +153,8 @@ class OveleonContaoCookiebarListener
             return null;
         }
 
-        $rootPage = $this->utils->request()->getCurrentRootPageModel();
+        $rootPage = $this->utils->request()
+            ->getCurrentRootPageModel();
         if (null === $rootPage) {
             return null;
         }
@@ -216,9 +220,12 @@ class OveleonContaoCookiebarListener
         // support legacy path for bc
         $legacyTemplateName = '@Contao/oveleon_cookiebar/blocker/default.html.twig';
         if (
-            $this->twig->getLoader()->exists($legacyTemplateName)
+            $this->twig->getLoader()
+                ->exists($legacyTemplateName)
             && !str_contains(
-                $this->twig->getLoader()->getSourceContext($legacyTemplateName)->getPath(),
+                $this->twig->getLoader()
+                    ->getSourceContext($legacyTemplateName)
+                    ->getPath(),
                 'heimrichhannot/contao-google-maps-bundle'
             )
         ) {

--- a/src/EventListener/ReplaceDynamicScriptTagsListener.php
+++ b/src/EventListener/ReplaceDynamicScriptTagsListener.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/HeimrichHannotGoogleMapsBundle.php
+++ b/src/HeimrichHannotGoogleMapsBundle.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Manager/MapManager.php
+++ b/src/Manager/MapManager.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
@@ -161,7 +161,8 @@ class MapManager
 
         if ($mapConfigModel) {
             $listener = new MapRendererListener($templateData['mapConfigModel'], $this, $mapHelper, $this->framework);
-            $mapHelper->getEventDispatcher()->addListener('map.stylesheet', [$listener, 'renderStylesheet']);
+            $mapHelper->getEventDispatcher()
+                ->addListener('map.stylesheet', [$listener, 'renderStylesheet']);
         }
 
         $templateData['mapHtml'] = $mapHelper->renderHtml($map);
@@ -229,7 +230,8 @@ class MapManager
         ;
 
         $listener = new ApiRenderListener($apiHelper, $this->eventDispatcher);
-        $apiHelper->getEventDispatcher()->addListener(ApiEvents::JAVASCRIPT, [$listener, 'onApiRender']);
+        $apiHelper->getEventDispatcher()
+            ->addListener(ApiEvents::JAVASCRIPT, [$listener, 'onApiRender']);
 
         $output = $apiHelper->render($this->mapCollection->getMaps());
 
@@ -287,7 +289,8 @@ class MapManager
 
         // clustering
         if ($mapConfig->addClusterer) {
-            $clusterer = $map->getOverlayManager()->getMarkerCluster();
+            $clusterer = $map->getOverlayManager()
+                ->getMarkerCluster();
             $clusterer->setType(MarkerClusterType::MARKER_CLUSTERER);
 
             if ($mapConfig->clustererImg) {
@@ -388,7 +391,8 @@ class MapManager
     {
         if ($mapConfig->staticMapNoscript) {
             $staticParams = [
-                'center' => $map->getCenter()->getLatitude().','.$map->getCenter()->getLongitude(),
+                'center' => $map->getCenter()
+                    ->getLatitude().','.$map->getCenter()->getLongitude(),
                 'zoom' => $map->getMapOption('zoom'),
                 'size' => $mapConfig->staticMapWidth.'x'.$mapConfig->staticMapHeight,
                 'maptype' => $map->getMapOption('mapTypeId'),
@@ -409,7 +413,8 @@ class MapManager
                 $mapConfig->mapTypeControlStyle,
             );
 
-            $map->getControlManager()->setMapTypeControl($control);
+            $map->getControlManager()
+                ->setMapTypeControl($control);
         } else {
             // Explicitly disable map type control when not enabled
             $map->setMapOption('mapTypeControl', false);
@@ -421,7 +426,8 @@ class MapManager
                 $mapConfig->zoomControlPos,
             );
 
-            $map->getControlManager()->setZoomControl($control);
+            $map->getControlManager()
+                ->setZoomControl($control);
         }
 
         // rotate
@@ -430,7 +436,8 @@ class MapManager
                 $mapConfig->rotateControlPos,
             );
 
-            $map->getControlManager()->setRotateControl($control);
+            $map->getControlManager()
+                ->setRotateControl($control);
         } else {
             // Explicitly disable rotate control when not enabled
             $map->setMapOption('rotateControl', false);
@@ -442,7 +449,8 @@ class MapManager
                 $mapConfig->streetViewControlPos,
             );
 
-            $map->getControlManager()->setStreetViewControl($control);
+            $map->getControlManager()
+                ->setStreetViewControl($control);
         } else {
             // Explicitly disable street view control when not enabled
             $map->setMapOption('streetViewControl', false);
@@ -454,7 +462,8 @@ class MapManager
                 $mapConfig->fullscreenControlPos,
             );
 
-            $map->getControlManager()->setFullscreenControl($control);
+            $map->getControlManager()
+                ->setFullscreenControl($control);
         } else {
             // Explicitly disable fullscreen control when not enabled
             $map->setMapOption('fullscreenControl', false);
@@ -464,7 +473,8 @@ class MapManager
         if ($mapConfig->addScaleControl) {
             $control = new ScaleControl();
 
-            $map->getControlManager()->setScaleControl($control);
+            $map->getControlManager()
+                ->setScaleControl($control);
         } else {
             // Explicitly disable scale control when not enabled
             $map->setMapOption('scaleControl', false);

--- a/src/Manager/OverlayManager.php
+++ b/src/Manager/OverlayManager.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */
@@ -67,10 +67,12 @@ class OverlayManager
             case OverlayListener::TYPE_MARKER:
                 [$marker, $events] = $this->prepareMarker($overlayConfig, $map);
 
-                $map->getOverlayManager()->addMarker($marker);
+                $map->getOverlayManager()
+                    ->addMarker($marker);
 
                 foreach ($events as $event) {
-                    $map->getEventManager()->addDomEvent($event);
+                    $map->getEventManager()
+                        ->addDomEvent($event);
                 }
 
                 break;
@@ -79,21 +81,24 @@ class OverlayManager
                 $infoWindow = $this->prepareInfoWindow($overlayConfig);
                 $infoWindow->setOpen(true);
 
-                $map->getOverlayManager()->addInfoWindow($infoWindow);
+                $map->getOverlayManager()
+                    ->addInfoWindow($infoWindow);
 
                 break;
 
             case OverlayListener::TYPE_KML_LAYER:
                 $kmlLayer = $this->prepareKmlLayer($overlayConfig);
 
-                $map->getLayerManager()->addKmlLayer($kmlLayer);
+                $map->getLayerManager()
+                    ->addKmlLayer($kmlLayer);
 
                 break;
 
             case OverlayListener::TYPE_POLYGON:
                 $polygon = $this->preparePolygon($overlayConfig);
 
-                $map->getOverlayManager()->addPolygon($polygon);
+                $map->getOverlayManager()
+                    ->addPolygon($polygon);
 
                 break;
 

--- a/src/Model/GoogleMapModel.php
+++ b/src/Model/GoogleMapModel.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Model/OverlayModel.php
+++ b/src/Model/OverlayModel.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Security/GoogleMapsPermissions.php
+++ b/src/Security/GoogleMapsPermissions.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Security/Voter/GoogleMapAccessVoter.php
+++ b/src/Security/Voter/GoogleMapAccessVoter.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Security/Voter/OverlayAccessVoter.php
+++ b/src/Security/Voter/OverlayAccessVoter.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Service/ElevationService.php
+++ b/src/Service/ElevationService.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Twig/GoogleMapsExtension.php
+++ b/src/Twig/GoogleMapsExtension.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Util/DcaUtil.php
+++ b/src/Util/DcaUtil.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */

--- a/src/Util/LocationUtil.php
+++ b/src/Util/LocationUtil.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) 2024 Heimrich & Hannot GmbH
+/**
+ * Copyright (c) 2024 Heimrich & Hannot GmbH.
  *
  * @license LGPL-3.0-or-later
  */


### PR DESCRIPTION
Contao 5.7 requires Symfony 7, which this bundle's constraints currently rule out.

## Symfony 7 (`df2fd82`)

Six constraints in `composer.json` are widened from `^6.4` to `^6.4 || ^7.0`:

`symfony/config`, `symfony/console`, `symfony/dependency-injection`, `symfony/event-dispatcher`, `symfony/http-foundation`, `symfony/http-kernel`

The change is purely additive — Symfony 6.4 stays supported, so nothing breaks for existing installations. No source changes were needed; the APIs in use are unchanged between 6.4 and 7.0.

**Caveat, unchanged from the original description:** this has only been smoke-tested, not run through a full Contao 5.7 installation. Treat it as "unblocks installation", not "verified on 5.7".

## Coding standard (`547adfd`)

A second commit was added to this branch: a plain `vendor/bin/ecs --fix` run over the existing files, 63 files, formatting only, no behaviour change.

Why it is here: ECS had started failing in CI on files untouched by this PR. The cause is time, not code — the repository's dev tooling is unpinned (`contao/contao-rector` is required as `dev-main`, `rector/rector` as `^2.3`), so newly resolved versions changed what the checkers flag. The same commits passed in March.

The changes are what the repository's own `ecs.php` produces: docblock separation and summaries, array indentation, standalone-line promoted properties, method chaining newlines, and line endings. Nothing hand-written.

If you would rather keep this PR to the Symfony change alone, I can split the ECS commit into its own PR — just say so.

## Known CI failure: rector

`rector` fails, and does so independently of both commits:

```
[ERROR] Undefined constant
        Rector\Doctrine\Set\DoctrineSetList::DOCTRINE_ORM_214
```

It fails while *loading* its configuration, before analysing a single file — hence no file list in the log. The constant no longer exists in current `rector/rector-doctrine`; it reaches the config through the Contao sets in `rector.php`. Since `contao/contao-rector` is `dev-main`, CI resolves a version without it, and the failure appeared without any change on our side.

Fixing it means pinning `contao/contao-rector` to a stable release (or committing `composer.lock`). I have deliberately left it alone here, as picking the version is a maintenance decision for this repository — happy to add it if you tell me which constraint you want.

## Related

#38 builds on this branch and adds a GeoJSON overlay type as the replacement for the deprecated `KmlLayer`. Once this PR is merged, that diff reduces to its actual 13 files.